### PR TITLE
Add alternate login via through 'burg'

### DIFF
--- a/submit_jobs_to_Ginsburg.md
+++ b/submit_jobs_to_Ginsburg.md
@@ -7,6 +7,8 @@ To gain access to the cluster, you must first get approval by emailing your UNI 
 ### Log In
 Log in to the secure [LDEO vpn](https://ldeo-it.ldeo.columbia.edu/content/vpn-virtual-private-network) with your LDEO username and password. From your terminal, SSH into the submit node: ```ssh -x <UNI>@ginsburg.rcs.columbia.edu``` ("-x" enables X11 forwarding). Enter your Columbia password and you will be in the directory ```/burg/home/<UNI>```. 
 
+Alternately, you can log in direcly to the `burg` filesystem using ```ssh -x <UNI>@burg.rcs.columbia.edu```. This route is useful if you are working with virtual python environments on the `burg` filesystem, because it will allow you more RAM to work with. 
+
 ### Start a Job with Slurm
 
 Ginsburg uses [Slurm](https://slurm.schedmd.com/documentation.html) to manage the cluster workload. A batch script is used to allocate resources and execute your job. You must specify an account when you're ready to submit a job to the cluster. 


### PR DESCRIPTION
I found that I can't install environments if I login through ginsburg.rcs.columbia.edu